### PR TITLE
Apply EXIF orientation if has

### DIFF
--- a/src/Image.ts
+++ b/src/Image.ts
@@ -16,7 +16,7 @@ export const getImage = async (image: sharp.Sharp): Promise<Image> => {
   const {
     info: { width, height, channels },
     data,
-  } = await image.raw().toBuffer({ resolveWithObject: true });
+  } = await image.rotate().raw().toBuffer({ resolveWithObject: true });
   const raw = await sharp(data, {
     raw: { width, height, channels },
   });


### PR DESCRIPTION
# Change:

Some image editing software updates only the EXIF orientation metadata instead of physically rotating the image. Most image viewers interpret this metadata and display the image accordingly.

However, JavaScript image processing libraries typically do not apply EXIF orientation by default. This can lead to incorrect rendering or orientation errors.

To address this, the orientation should be applied manually (if present) before passing the image into raw().

# Related post: 

https://stackoverflow.com/questions/74948926/wrong-image-width-and-height-when-read-it-with-c-sharp

# Demo video: 

https://youtu.be/npjw7FiSgng